### PR TITLE
run()の引数xに空配列のデフォルト値を設定

### DIFF
--- a/skqulacs/circuit/circuit.py
+++ b/skqulacs/circuit/circuit.py
@@ -118,7 +118,7 @@ class LearningCircuit:
                 parameter.value = angle
                 self._circuit.set_parameter(parameter.pos, angle)
 
-    def run(self, x: List[float]) -> QuantumState:
+    def run(self, x: List[float] = list()) -> QuantumState:
         """Determine parameters for input gate based on `x` and apply the circuit to |0> state.
 
         Arguments:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -30,7 +30,7 @@ def test_parametric_gates_mixed():
     circuit.run([1.0])
     assert [0.2, 2.0] == circuit.get_parameters()
 
+
 def test_no_arg_run():
     circuit = LearningCircuit(2)
-    state = circuit.run()
-    print(state.get_vector())
+    circuit.run()

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -29,3 +29,8 @@ def test_parametric_gates_mixed():
     circuit.update_parameters([0.2, 1.0])
     circuit.run([1.0])
     assert [0.2, 2.0] == circuit.get_parameters()
+
+def test_no_arg_run():
+    circuit = LearningCircuit(2)
+    state = circuit.run()
+    print(state.get_vector())


### PR DESCRIPTION
生成モデル等の場合入力データが無い場合があるため、run()に引数がない場合でも動くようにする。