### PR TITLE
Turn off jupyter exec

### DIFF
--- a/CONTRIBUTING-en.md
+++ b/CONTRIBUTING-en.md
@@ -107,9 +107,10 @@ By running this command, the documentation is built and you can access it from [
 ### Create Page from jupyter notebook
 You can create jupyter notebook from jupyter notebook.
 It is useful to show an example usage of APIs in this library.
-1. Create `.ipynb` file in the `doc/source/notebooks`(suppose `0_tutorial.ipynb` here)
-2. Add the file name without its extension to `doc/source/notebooks/index.rst`
-3. Execute `make html` or `make serve` to generate HTMLs
+1. Create `.ipynb` file in the `doc/source/notebooks`(suppose `0_tutorial.ipynb` here).
+2. Edit the contents and **be sure to execute all cells without error**. Code and results in the notebook is embedded to documentation without modification.
+3. Add the file name without its extension to `doc/source/notebooks/index.rst`.
+4. Execute `make html` or `make serve` to generate HTMLs.
 
 Example of `doc/source/notebook/index.rst`:
 ```

--- a/CONTRIBUTING-en.md
+++ b/CONTRIBUTING-en.md
@@ -1,5 +1,8 @@
 # Contributing scikit-qulacs
 
+## Requirements
+- poetry([installation](https://python-poetry.org/docs/#installation))
+
 ## Start coding
 Set up the project.
 1. First, clone this repository.
@@ -10,10 +13,7 @@ cd scikit-qulacs
 
 2. Install dependencies and development tools.
 ```bash
-pip install -r requirements-dev.txt
-# This installs dependencies and creates a symbolic link to this directory in 
-# the site-packages directory.
-make install
+poetry install
 ```
 
 Next, workflow through modification to merge.
@@ -83,21 +83,6 @@ The purpose of CI is
 * Find error you cannot notice at your local machine.
 * Avoid unnecessary diff by forcing code format and linter error.
 
-## Installation
-You can install skqulacs to your python's site-packages by `setup-tools`.
-Although `make install` just creates a symlink to this directory, this method builds a complete package.
-
-First, install `build`.
-```bash
-pip install build
-```
-Then, build and install this package.
-```bash
-python -m build
-# This file name might be different among environments.
-pip install dist/scikit_qulacs-0.0.1-py3-none-any.whl
-```
-
 ## Documentation
 This repository's documentation includes API document and Jupyter Notebook style tutorials.
 
@@ -105,31 +90,28 @@ The documentation is available here: https://qulacs-osaka.github.io/scikit-qulac
 It is built and deployed on pushing(merged from PR) to `main` branch.
 
 ### Build document
-First, move into `doc`.
-```bash
-cd doc
-```
-
-You can install dependencies to build docs in a following command.
-```bash
-pip install -r requirements-doc.txt
-```
-
-Then just run following command.
+Just run following command.
 ```bash
 make html
 ```
 
 In `doc/build/html`, you can find build artifacts including HTML files.
 
+Or you can check artifacts via browser easily.
+```bash
+make serve
+```
+By running this command, the documentation is built and you can access it from [`localhost:8080`](http://localhost:8000/).
+
 
 ### Create Page from jupyter notebook
-jupyter notebook からページを作ることができます．ライブラリの使用例などを書くのに便利です．
-1. `doc/source/notebooks` に ipynb ファイルを作って編集する(0_example.ipynb とする)
-2. `doc/source/notebook/index.rst` にそのファイル名を拡張子なしで追記する(*)
-3. `make html -C doc` を実行すると HTML が生成されるのでブラウザなどで開く
+You can create jupyter notebook from jupyter notebook.
+It is useful to show an example usage of APIs in this library.
+1. Create `.ipynb` file in the `doc/source/notebooks`(suppose `0_tutorial.ipynb` here)
+2. Add the file name without its extension to `doc/source/notebooks/index.rst`
+3. Execute `make html` or `make serve` to generate HTMLs
 
-(*) `doc/source/notebook/index.rst` の一部を抜粋します:
+Example of `doc/source/notebook/index.rst`:
 ```
 Notebooks
 ---------
@@ -139,4 +121,4 @@ Notebooks
    0_tutorial
 ```
 
-LaTeX や画像なども表示できます．
+You can display LaTeX and images.

--- a/CONTRIBUTING-en.md
+++ b/CONTRIBUTING-en.md
@@ -105,7 +105,7 @@ By running this command, the documentation is built and you can access it from [
 
 
 ### Create Page from jupyter notebook
-You can create jupyter notebook from jupyter notebook.
+You can create a documentation page from jupyter notebook.
 It is useful to show an example usage of APIs in this library.
 1. Create `.ipynb` file in the `doc/source/notebooks`(suppose `0_tutorial.ipynb` here).
 2. Edit the contents and **be sure to execute all cells without error**. Code and results in the notebook is embedded to documentation without modification.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -73,3 +73,11 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+
+# Some cells which requires longer time to finish raises `KeyboardInterrupt`.
+# They are seemed to be interrupted by Sphinx.
+# It is troublesome to annotate cells which spends more time, so turn off
+# execution of jupyter notebook on documentation build.
+# There is no problem for now because every notebook embedded in documetation
+# is executed once at local environment and the result is committed.
+jupyter_execute_notebooks = "off"

--- a/doc/source/notebooks/paper_reproduction.rst
+++ b/doc/source/notebooks/paper_reproduction.rst
@@ -1,5 +1,5 @@
 Reproducing papers
----------
+==================
 
 .. toctree::
    arxiv_2108_01039_large_scale_quantum_machine_learning

--- a/doc/source/skqulacs.circuit.graph.rst
+++ b/doc/source/skqulacs.circuit.graph.rst
@@ -1,7 +1,0 @@
-skqulacs.circuit.graph module
-=============================
-
-.. automodule:: skqulacs.circuit.graph
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/doc/source/skqulacs.circuit.rst
+++ b/doc/source/skqulacs.circuit.rst
@@ -8,7 +8,6 @@ Submodules
    :maxdepth: 4
 
    skqulacs.circuit.circuit
-   skqulacs.circuit.graph
    skqulacs.circuit.pre_defined
 
 Module contents

--- a/doc/source/skqulacs.qsvm.qsvmbase.rst
+++ b/doc/source/skqulacs.qsvm.qsvmbase.rst
@@ -1,7 +1,0 @@
-skqulacs.qsvm.qsvmbase module
-=============================
-
-.. automodule:: skqulacs.qsvm.qsvmbase
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/doc/source/skqulacs.qsvm.rst
+++ b/doc/source/skqulacs.qsvm.rst
@@ -8,7 +8,6 @@ Submodules
    :maxdepth: 4
 
    skqulacs.qsvm.qsvc
-   skqulacs.qsvm.qsvmbase
    skqulacs.qsvm.qsvr
 
 Module contents

--- a/doc/source/skqulacs.rst
+++ b/doc/source/skqulacs.rst
@@ -11,14 +11,6 @@ Subpackages
    skqulacs.qnn
    skqulacs.qsvm
 
-Submodules
-----------
-
-.. toctree::
-   :maxdepth: 4
-
-   skqulacs.typing
-
 Module contents
 ---------------
 

--- a/doc/source/skqulacs.typing.rst
+++ b/doc/source/skqulacs.typing.rst
@@ -1,7 +1,0 @@
-skqulacs.typing module
-======================
-
-.. automodule:: skqulacs.typing
-   :members:
-   :undoc-members:
-   :show-inheritance:


### PR DESCRIPTION
close #137 
実行に時間がかかるセルがあると `KeyboardInterrupt` が発生してしまうようなので，ドキュメントのビルド時に jupyter notebook を実行しないようにしました．
ドキュメントに載せる notebook は一度実行された状態で commit されるため，このようにしても問題ないと考えました．