### PR TITLE
Share learning parameters

### DIFF
--- a/skqulacs/circuit/circuit.py
+++ b/skqulacs/circuit/circuit.py
@@ -318,7 +318,7 @@ class LearningCircuit:
     ) -> int:
         """
         Args:
-            index: Index of qubit to add RX gate.
+            index: Index of qubit to add RY gate.
             parameter: Initial parameter of this gate.
             share_with: parameter_id to share the parameter in `ParametricQuantumCircuit`.
 
@@ -332,7 +332,7 @@ class LearningCircuit:
     ) -> int:
         """
         Args:
-            index: Index of qubit to add RX gate.
+            index: Index of qubit to add RZ gate.
             parameter: Initial parameter of this gate.
             share_with: parameter_id to share the parameter in `ParametricQuantumCircuit`.
 

--- a/skqulacs/circuit/circuit.py
+++ b/skqulacs/circuit/circuit.py
@@ -178,7 +178,7 @@ class LearningCircuit:
         """
         self._set_input(x)
         ret = self._circuit.backprop(obs)
-        ans = [0] * len(self._learning_parameter_list)
+        ans = [0.0] * len(self._learning_parameter_list)
         for parameter in self._learning_parameter_list:
             if not parameter.is_input:
                 for pos in parameter.positions_in_circuit:
@@ -303,6 +303,10 @@ class LearningCircuit:
         Args:
             index: Index of qubit to add RX gate.
             parameter: Initial parameter of this gate.
+            share_with: parameter_id to share the parameter in `ParametricQuantumCircuit`.
+
+        Returns:
+            parameter_id which is added or updated.
         """
         return self._add_parametric_R_gate_inner(index, parameter, _Axis.X, share_with)
 
@@ -311,8 +315,12 @@ class LearningCircuit:
     ) -> int:
         """
         Args:
-            index: Index of qubit to add RY gate.
+            index: Index of qubit to add RX gate.
             parameter: Initial parameter of this gate.
+            share_with: parameter_id to share the parameter in `ParametricQuantumCircuit`.
+
+        Returns:
+            parameter_id which is added or updated.
         """
         return self._add_parametric_R_gate_inner(index, parameter, _Axis.Y, share_with)
 
@@ -321,8 +329,12 @@ class LearningCircuit:
     ) -> int:
         """
         Args:
-            index: Index of qubit to add RZ gate.
+            index: Index of qubit to add RX gate.
             parameter: Initial parameter of this gate.
+            share_with: parameter_id to share the parameter in `ParametricQuantumCircuit`.
+
+        Returns:
+            parameter_id which is added or updated.
         """
         return self._add_parametric_R_gate_inner(index, parameter, _Axis.Z, share_with)
 

--- a/skqulacs/circuit/circuit.py
+++ b/skqulacs/circuit/circuit.py
@@ -13,7 +13,9 @@ class _Axis(Enum):
     Z = auto()
 
 
-InputFunc = Callable[[List[float]], float]  # Depends on x
+# Depends on x
+InputFunc = Callable[[List[float]], float]
+
 # Depends on theta, x
 InputFuncWithParam = Callable[[float, List[float]], float]
 
@@ -90,7 +92,8 @@ class LearningCircuit:
         >>> from skqulacs.qnn.regressor import QNNRegressor
         >>> n_qubit = 2
         >>> circuit = LearningCircuit(n_qubit)
-        >>> circuit.add_parametric_RX_gate(0, 0.5)
+        >>> theta = circuit.add_parametric_RX_gate(0, 0.5)
+        >>> circuit.add_parametric_RY_gate(1, 0.1, share_with=theta)
         >>> circuit.add_input_RZ_gate(1, np.arcsin)
         >>> model = QNNRegressor(circuit)
         >>> _, theta = model.fit(x_train, y_train, maxiter=1000)
@@ -108,10 +111,10 @@ class LearningCircuit:
         self._input_parameter_list: List[_InputParameter] = []
 
     def update_parameters(self, theta: List[float]) -> None:
-        """Update learning parameter of the circuit.
+        """Update learning parameter of the circuit with given `theta`.
 
         Args:
-            theta: New learning parameter.
+            theta: New learning parameters.
         """
         for parameter in self._learning_parameter_list:
             parameter_value = theta[parameter.parameter_id]
@@ -120,7 +123,7 @@ class LearningCircuit:
                 self._circuit.set_parameter(pos, parameter_value)
 
     def get_parameters(self) -> List[float]:
-        """Get a list of learning parameters."""
+        """Get a list of learning parameters' values."""
         theta_list = [p.value for p in self._learning_parameter_list]
         return theta_list
 
@@ -187,7 +190,7 @@ class LearningCircuit:
         return ans
 
     def _new_parameter_position(self) -> int:
-        """Return a position of a new parameter in `ParametricQuantumCircuit`.
+        """Return a position of a new parameter to be registered to `ParametricQuantumCircuit`.
         This function does not actually register a new parameter.
         """
         return self._circuit.get_parameter_count()
@@ -245,18 +248,18 @@ class LearningCircuit:
         """
         self._add_R_gate_inner(index, parameter, _Axis.Z)
 
-    def add_CNOT_gate(self, indexA: int, indexB: int) -> None:
+    def add_CNOT_gate(self, control_index: int, target_index: int) -> None:
         """
         Args:
-            indexA: Index of qubit to CNOT gate.
-            indexB: Index of qubit to CNOT gate.
+            control_index: Index of control qubit.
+            target_index: Index of target qubit.
         """
-        self._circuit.add_CNOT_gate(indexA, indexB)
+        self._circuit.add_CNOT_gate(control_index, target_index)
 
     def add_H_gate(self, index: int) -> None:
         """
         Args:
-            index: Index of qubit to H gate.
+            index: Index of qubit to put H gate.
         """
         self._circuit.add_H_gate(index)
 
@@ -268,7 +271,7 @@ class LearningCircuit:
         """
         Args:
             index: Index of qubit to add RX gate.
-            input_func: Function transforming index value.
+            input_func: Function transforming input value.
         """
         self._add_input_R_gate_inner(index, _Axis.X, input_func)
 
@@ -280,7 +283,7 @@ class LearningCircuit:
         """
         Args:
             index: Index of qubit to add RY gate.
-            input_func: Function transforming index value.
+            input_func: Function transforming input value.
         """
         self._add_input_R_gate_inner(index, _Axis.Y, input_func)
 
@@ -292,7 +295,7 @@ class LearningCircuit:
         """
         Args:
             index: Index of qubit to add RZ gate.
-            input_func: Function transforming index value.
+            input_func: Function transforming input value.
         """
         self._add_input_R_gate_inner(index, _Axis.Z, input_func)
 
@@ -348,7 +351,7 @@ class LearningCircuit:
         Args:
             index: Index of qubit to add RX gate.
             parameter: Initial parameter of this gate.
-            input_func: Function transforming this gate's parameter and index value.
+            input_func: Function transforming this gate's parameter and input value.
         """
         self._add_parametric_input_R_gate_inner(index, parameter, _Axis.X, input_func)
 
@@ -362,7 +365,7 @@ class LearningCircuit:
         Args:
             index: Index of qubit to add RY gate.
             parameter: Initial parameter of this gate.
-            input_func: Function transforming this gate's parameter and index value.
+            input_func: Function transforming this gate's parameter and input value.
         """
         self._add_parametric_input_R_gate_inner(index, parameter, _Axis.Y, input_func)
 
@@ -376,7 +379,7 @@ class LearningCircuit:
         Args:
             index: Index of qubit to add RZ gate.
             parameter: Initial parameter of this gate.
-            input_func: Function transforming this gate's parameter and index value.
+            input_func: Function transforming this gate's parameter and input value.
         """
         self._add_parametric_input_R_gate_inner(index, parameter, _Axis.Z, input_func)
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -46,12 +46,18 @@ def test_share_learning_parameter():
     assert [0.1] == circuit.get_parameters()
 
 
+def test_share_input_learning_parameter():
+    circuit = LearningCircuit(2)
+    circuit.add_parametric_RX_gate(0, 0.0)
+    circuit.add_parametric_RY_gate(1, 0.0, share_with=0)
+    circuit.update_parameters([0.1])
+    assert [0.1] == circuit.get_parameters()
+
+
 def test_running_shared_parameter():
     circuit = LearningCircuit(2)
     shared_parameter = circuit.add_parametric_RX_gate(0, 0.0)
-    circuit.add_parametric_RY_gate(
-        1, 0.0, share_with=shared_parameter
-    )  # Compute RY gate with shared parameter 0.
+    circuit.add_parametric_RY_gate(1, 0.0, share_with=shared_parameter)
     assert [0.0] == circuit.get_parameters()
 
     circuit_without_share = LearningCircuit(2)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -34,3 +34,34 @@ def test_parametric_gates_mixed():
 def test_no_arg_run():
     circuit = LearningCircuit(2)
     circuit.run()
+
+
+def test_share_learning_parameter():
+    circuit = LearningCircuit(2)
+    circuit.add_parametric_RX_gate(0, 0.0)  # parameter 0.
+    circuit.add_parametric_RY_gate(
+        1, 0.0, share_with=0
+    )  # Compute RY gate with shared parameter 0.
+    circuit.update_parameters([0.1])
+    assert [0.1] == circuit.get_parameters()
+
+
+def test_running_shared_parameter():
+    circuit = LearningCircuit(2)
+    shared_parameter = circuit.add_parametric_RX_gate(0, 0.0)
+    circuit.add_parametric_RY_gate(
+        1, 0.0, share_with=shared_parameter
+    )  # Compute RY gate with shared parameter 0.
+    assert [0.0] == circuit.get_parameters()
+
+    circuit_without_share = LearningCircuit(2)
+    circuit_without_share.add_parametric_RX_gate(0, 0.0)
+    circuit_without_share.add_parametric_RY_gate(1, 0.0)
+
+    circuit.update_parameters([0.1])
+    circuit_without_share.update_parameters([0.1, 0.1])
+
+    state = circuit.run([])
+    state_without_share = circuit_without_share.run([])
+    for v, w in zip(state.get_vector(), state_without_share.get_vector()):
+        assert v == w


### PR DESCRIPTION
close #141 
ひとつの `_LearningParameter` を介して `ParametricQuantumCircuit` 内の複数のパラメータを制御できるようになりました．

@WATLE backprop の部分は，各 `_LearningParameter` が共有している `ParametricQuantumCircuit` の backprop を足し合わせるように実装したんですが，これで問題なさそうか確認お願いします．