### PR TITLE
Update makefile

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,6 @@ make check
 make test
 ```
 
-Code format and some lint errors can be fixed by `make fix`.
-Rest of lint errors should be fixed by hand along error messages.
-
 6. Commit and push modified files.
 ```bash
 git add MODIFIED_FILE

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,19 +3,19 @@
 ## Running benchmarks
 To run benchmarks, run following command at the project root.
 ```bash
-make benchmarks
+make benchmark
 ```
 Then benchmark statistics are displayed and you will find a JSON file at `.benchmarks/<SYSTEM_SPECIFIC_DIR>/*.json`.
 This is the summary of the benchmark runs.
 
-You can plot the result by `benchmarks/plot_result.py` with the generated JSON file.
+You can plot the result by `benchmarks/plot_results.py` with the generated JSON file.
 ```bash
-python benchmarks/plot_result.py .benchmarks/<SYSTEM_SPECIFIC_DIR>/*.json
+python benchmarks/plot_results.py .benchmarks/<SYSTEM_SPECIFIC_DIR>/*.json
 ```
 The rendered image is exported at `.benchmarks/outputs`.
 You can specify the directory wherever you like by `-o`(`--output_dir`) option.
 ```bash
-python benchmarks/plot_result.py .benchmarks/<SYSTEM_SPECIFIC_DIR>/*.json -o doc/source/figures
+python benchmarks/plot_results.py .benchmarks/<SYSTEM_SPECIFIC_DIR>/*.json -o doc/source/figures
 ```
 
 ## Add benchmarks
@@ -62,14 +62,14 @@ This is the summary of the benchmark runs.
 
 ## Plot
 ### Generate plotted images
-You can plot the result by `benchmarks/plot_result.py` with the generated JSON file.
+You can plot the result by `benchmarks/plot_results.py` with the generated JSON file.
 ```bash
-python benchmarks/plot_result.py .benchmarks/<SYSTEM_SPECIFIC_DIR>/*.json
+python benchmarks/plot_results.py .benchmarks/<SYSTEM_SPECIFIC_DIR>/*.json
 ```
 The rendered image is exported at `.benchmarks/outputs`.
 You can specify the directory wherever you like by `-o`(`--output_dir`) option.
 ```bash
-python benchmarks/plot_result.py .benchmarks/<SYSTEM_SPECIFIC_DIR>/*.json -o doc/source/figures
+python benchmarks/plot_results.py .benchmarks/<SYSTEM_SPECIFIC_DIR>/*.json -o doc/source/figures
 ```
 
 ### Write a plot


### PR DESCRIPTION
close #182 
今まで手元での静的解析は `make check` -> `make fix` というフローでやっていましたが，`make check` だけでフォーマッタの実行・import 文のソート・lint error のチェックを実行します．
push 前には `make check` を実行して，もしあれば lint error を修正するだけでよいです．