### PR TITLE
#246 benchmarkの学習回数が一致していない

### DIFF
--- a/benchmarks/binary_classification_pennylane.py
+++ b/benchmarks/binary_classification_pennylane.py
@@ -143,7 +143,7 @@ def train(
     best_weights = weights
     best_bias = bias
     best_acc_val = 0.0
-    n_epoch = 20
+    n_epoch = 10
     for epoch in range(n_epoch):
         # Update the weights by one optimizer step
         batch_index = rng.integers(0, len(x_train), (batch_size,))

--- a/benchmarks/binary_classification_skqulacs.py
+++ b/benchmarks/binary_classification_skqulacs.py
@@ -94,6 +94,6 @@ def binary_classification_skqulacs(
     num_class = 2
     circuit = create_circuit(6)
     qcl = QNNClassifier(circuit, num_class, Adam(), do_x_scale=False)
-    qcl.fit(x_train, y_train, 100)
+    qcl.fit(x_train, y_train, 50)
     y_pred = qcl.predict(x_test)
     f1_score(y_test, y_pred) > 0.95

--- a/benchmarks/binary_classification_skqulacs.py
+++ b/benchmarks/binary_classification_skqulacs.py
@@ -94,6 +94,6 @@ def binary_classification_skqulacs(
     num_class = 2
     circuit = create_circuit(6)
     qcl = QNNClassifier(circuit, num_class, Adam(), do_x_scale=False)
-    qcl.fit(x_train, y_train, 50)
+    qcl.fit(x_train, y_train, 100)
     y_pred = qcl.predict(x_test)
     f1_score(y_test, y_pred) > 0.95


### PR DESCRIPTION
irisのデータが100件で、trainデータに75件取っているので、学習データは50件にあわせます。
penylaneは、n_epoch = 20で、それぞれbatch_size = 5でデータを取っているので20x5で100データだったので、n_epoch = 10 にしました。
https://github.com/Qulacs-Osaka/scikit-qulacs/blob/main/benchmarks/binary_classification_pennylane.py#L149
scikit-qulacs