### PR TITLE
fix docstring for QNNClassifier

### DIFF
--- a/skqulacs/qnn/classifier.py
+++ b/skqulacs/qnn/classifier.py
@@ -37,11 +37,14 @@ class QNNClassifier:
     Examples:
         >>> from skqulacs.qnn import QNNClassifier
         >>> from skqulacs.circuit import create_qcl_ansatz
+        >>> from skqulacs.qnn.solver import Bfgs
         >>> n_qubits = 4
         >>> depth = 3
         >>> evo_time = 0.5
+        >>> num_class = 3
+        >>> solver = Bfgs()
         >>> circuit = create_qcl_ansatz(n_qubits, depth, evo_time)
-        >>> model = QNNRClassifier(circuit)
+        >>> model = QNNClassifier(circuit, num_class, solver)
         >>> _, theta = model.fit(x_train, y_train, maxiter=1000)
         >>> x_list = np.arange(x_min, x_max, 0.02)
         >>> y_pred = qnn.predict(theta, x_list)


### PR DESCRIPTION
It seems the current docstring in `QNNClassifier` is not consistent with the actual usage of that. Indeed we get:

<img width="957" alt="image" src="https://user-images.githubusercontent.com/16760547/194736463-12928142-a28d-4d96-aa7e-2ec36431c234.png">

Let's update this.