### PR TITLE
Replace Pauli([0], [1]) with X gate

### DIFF
--- a/benchmarks/binary_classification_skqulacs.py
+++ b/benchmarks/binary_classification_skqulacs.py
@@ -49,12 +49,12 @@ def create_circuit(depth: int) -> LearningCircuit:
         circuit.add_CNOT_gate(0, 1)
         circuit.add_input_RY_gate(1)
 
-        circuit.add_gate(Pauli([0], [1]))  # Pauli X on 0th qubit
+        circuit.add_X_gate(0)
         circuit.add_CNOT_gate(0, 1)
         circuit.add_input_RY_gate(1)
         circuit.add_CNOT_gate(0, 1)
         circuit.add_input_RY_gate(1)
-        circuit.add_gate(Pauli([0], [1]))
+        circuit.add_X_gate(0)
 
     def add_layer(circuit: LearningCircuit, rng: Generator) -> None:
         circuit.add_parametric_RZ_gate(0, rng.random())

--- a/benchmarks/binary_classification_skqulacs.py
+++ b/benchmarks/binary_classification_skqulacs.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 from binary_classification_common import preprocess_input
 from numpy.random import Generator, default_rng
-from qulacs.gate import Pauli
 from sklearn import datasets
 from sklearn.metrics import f1_score
 from sklearn.model_selection import train_test_split


### PR DESCRIPTION
なぜか複数量子ビットに対するパウリゲートを使っており，このゲートは `get_inverse()` を持っていないためベンチマークが通りませんでした([例](https://github.com/Qulacs-Osaka/scikit-qulacs/actions/runs/4022560906/jobs/6949611055))．
単に X ゲートを作用させればよいので，`add_X_gate()` に置き換えました．